### PR TITLE
함수 이름 수정

### DIFF
--- a/docs/002_deep_learning_part_1/0023.md
+++ b/docs/002_deep_learning_part_1/0023.md
@@ -85,7 +85,7 @@ L = - \sum_{i=1}^C t_i \log y_i
 $$
 
 ```python
-def square_loss(y, t):
+def categorical_crossentropy(y, t):
     return -tf.reduce_mean(t * log(y + 1e-7))
 ```
 ---


### PR DESCRIPTION
Categorical Cross Entropy 의 파이썬 함수 이름이 `square_loss` 로 되어 있던 오류를 수정했습니다.